### PR TITLE
Corrected clock. 25Mhz, SysClock at 48Mhz (should be better for USB a…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846
+	// for the documentation about the extensions.json format
+	"recommendations": [
+		"platformio.platformio-ide"
+	]
+}

--- a/TFT/src/Libraries/cmsis/stm32f10x/system_stm32f10x.c
+++ b/TFT/src/Libraries/cmsis/stm32f10x/system_stm32f10x.c
@@ -106,6 +106,8 @@
 #if defined (STM32F10X_LD_VL) || (defined STM32F10X_MD_VL) || (defined STM32F10X_HD_VL)
 /* #define SYSCLK_FREQ_HSE    HSE_VALUE */
  #define SYSCLK_FREQ_24MHz  24000000
+#elif defined (MKS_32_V1_4)
+ #define SYSCLK_FREQ_48MHz  48000000
 #else
 /* #define SYSCLK_FREQ_HSE    HSE_VALUE */
 /* #define SYSCLK_FREQ_24MHz  24000000 */ 

--- a/TFT/src/User/Hal/STM32_USB_HOST_Library/Usr/src/usb_bsp.c
+++ b/TFT/src/User/Hal/STM32_USB_HOST_Library/Usr/src/usb_bsp.c
@@ -42,7 +42,11 @@ void USB_OTG_BSP_Init(USB_OTG_CORE_HANDLE * pdev)
   // EXTI_InitTypeDef EXTI_InitStructure;
 #ifdef STM32F10X_CL
 
+#if defined(MKS_32_V1_4)  
+  RCC_OTGFSCLKConfig(RCC_OTGFSCLKSource_PLLVCO_Div2);
+#else
   RCC_OTGFSCLKConfig(RCC_OTGFSCLKSource_PLLVCO_Div3);
+#endif
   RCC_AHBPeriphClockCmd(RCC_AHBPeriph_OTG_FS, ENABLE);
 
 #else                           // USE_STM322xG_EVAL

--- a/TFT/src/User/Hal/stm32f10x/usart.c
+++ b/TFT/src/User/Hal/stm32f10x/usart.c
@@ -1,16 +1,24 @@
 #include "usart.h"
 #include "GPIO_Init.h"
 
+#if defined(MKS_32_V1_4)
+static USART_TypeDef *usart[_USART_CNT] = {
+  USART1,  //TX--PA9  RX--PA10
+  USART2,  //TX--PD5  RX--PD6 UART2 ALT CONFIG (Speaker on Defaulty Pin)
+  USART3   //TX--PD8 RX--PD9 UART3 ALT CONFIG
+};
+#else
 static USART_TypeDef *usart[_USART_CNT] = {
   USART1,  //TX--PA9  RX--PA10
   USART2,  //PD5 PD6 --TX--PA2  RX--PA3
   USART3,  //TX--PB10 RX--PB11
   UART4,   //TX--PC10 RX--PC11
   UART5};  //TX--PC12 RX--PD2
+#endif
 
 #if defined(MKS_32_V1_4)
-static const uint16_t uart_tx[_USART_CNT] = {PA9,  PD5, PD8, PC10, PC12}; //TX
-static const uint16_t uart_rx[_USART_CNT] = {PA10, PD6, PD9, PC11, PD2};  //RX
+static const uint16_t uart_tx[_USART_CNT] = {PA9,  PD5, PD8}; //TX
+static const uint16_t uart_rx[_USART_CNT] = {PA10, PD6, PD9};  //RX
 #else
 static const uint16_t uart_tx[_USART_CNT] = {PA9,  PA2, PB10, PC10, PC12}; //TX
 static const uint16_t uart_rx[_USART_CNT] = {PA10, PA3, PB11, PC11, PD2};  //RX

--- a/TFT/src/User/variants.h
+++ b/TFT/src/User/variants.h
@@ -72,10 +72,8 @@
 #else
   #define VECT_TAB_FLASH 0x0807000
 #endif
-  //#define HSE_VALUE ((uint32_t)8000000) //8Mhz
-  #define HSE_VALUE ((uint32_t)16000000) //16Mhz
-  //#define HSE_VALUE ((uint32_t)25000000) //16Mhz
-  #define F_CPUM 72
+  #define HSE_VALUE ((uint32_t)25000000) //25Mhz XTAL
+  #define F_CPUM 48
   #define STM32F10X_CL
   #include "stm32f10x.h"
 #endif
@@ -122,8 +120,8 @@
   #define SERIAL_PORT_3 _USART3
   #define SERIAL_PORT_4 _UART4
 #elif defined(MKS_32_V1_4)
-  #define SERIAL_PORT   _USART1
-  #define SERIAL_PORT_2 _USART2
+  #define SERIAL_PORT   _USART2
+  #define SERIAL_PORT_2 _USART1
   #define SERIAL_PORT_3 _USART3
  // #define SERIAL_PORT_4 _UART4
 #endif

--- a/TFT/src/User/variants.h
+++ b/TFT/src/User/variants.h
@@ -255,8 +255,8 @@
   #define U_DISK_SUPPROT
   #define USE_USB_OTG_FS
 #elif defined(MKS_32_V1_4)
-  //#define U_DISK_SUPPROT
-  //#define USE_USB_OTG_FS
+  #define U_DISK_SUPPROT
+  #define USE_USB_OTG_FS
 #endif
 
 //extend function(PS_ON, filament_detect)
@@ -274,12 +274,10 @@
 //Debug disable, free pins for other function
 #if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2) || defined(TFT28_V1_0) || defined(TFT35_V2_0)
   #define DISABLE_JTAG    //free JTAG(PB3/PB4) for SPI3
-#elif defined(TFT24_V1_1)
-  #define DISABLE_DEBUG   //
+#elif defined(TFT24_V1_1) 
+  #define DISABLE_DEBUG   
 #elif defined(TFT35_V3_0)
   //stm32f207 needn't this
-#elif defined(MKS_32_V1_4)
-  //stm32f107 dont need this offf
 #endif
 
 //LCD resolution, font and icon size

--- a/platformio.ini
+++ b/platformio.ini
@@ -167,11 +167,10 @@ build_flags   = ${stm32f10x.build_flags}
 platform      = ststm32
 framework     = stm32cube
 board         = STM32F107VC
-upload_protocol = blackmagic
-debug_tool = blackmagic
-debug_port = com2
-upload_port = com2
-
+upload_protocol = stlink
+debug_tool = stlink
+;debug_port = com2
+;upload_port = com2
 src_filter    = ${stm32f10x.default_src_filter} +<src/Libraries/Startup/stm32f10x_hd>
 extra_scripts = pre:buildroot/scripts/custom_filename.py
                 buildroot/scripts/stm32f10x_0x7000_iap.py


### PR DESCRIPTION
Corrected clock. Using XTAL of 25Mhz, SysClock at 48Mhz (should be better for USB as well). No more UART sync issues.

Also, moved Primary UART to UART2 (Printer Comms)